### PR TITLE
Remove extraneous title info and alphabetize

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 Plugins for additional [Gutenberg](https://wordpress.org/gutenberg/) block types.
 
 ## Table Of Contents
-* [Plugins](#plugins)
+* [Block Plugins](#plugins)
 
-## Plugins
-* [Gutenberg Blocks – Ultimate Addons for Gutenberg](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) - The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
-* [Stackable – Gutenberg Blocks](https://wordpress.org/plugins/stackable-ultimate-gutenberg-blocks/) - Blocks for everyone.
+## Block Plugins
+* [Ultimate Addons for Gutenberg](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) - The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
+* [Stackable](https://wordpress.org/plugins/stackable-ultimate-gutenberg-blocks/) - Blocks for everyone.
 * [Advanced Gutenberg](https://wordpress.org/plugins/advanced-gutenberg/) - Enhanced tools for Gutenberg editor.
-* [Atomic Blocks – Gutenberg Blocks Collection](https://wordpress.org/plugins/atomic-blocks/) - A beautiful collection of handy Gutenberg blocks to help you get started with the new WordPress editor.
-* [Kadence Blocks – Gutenberg Page Builder Toolkit](https://wordpress.org/plugins/kadence-blocks/) - Advanced Page Building Blocks for Gutenberg. Create custom column layouts, backgrounds, dual buttons, icons etc.
-* [Page Builder Gutenberg Blocks – CoBlocks](https://wordpress.org/plugins/coblocks/) - CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
+* [Atomic Blocks](https://wordpress.org/plugins/atomic-blocks/) - A beautiful collection of handy Gutenberg blocks to help you get started with the new WordPress editor.
+* [Kadence Blocks](https://wordpress.org/plugins/kadence-blocks/) - Advanced Page Building Blocks for Gutenberg. Create custom column layouts, backgrounds, dual buttons, icons etc.
+* [CoBlocks](https://wordpress.org/plugins/coblocks/) - CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
 * [Advanced Gutenberg Blocks](https://wordpress.org/plugins/advanced-gutenberg-blocks/) - Awesome customizable blocks for the new WordPress Editor.
-* [Gutenberg Blocks and Template Library by Otter](https://wordpress.org/plugins/otter-blocks/) - Create beautiful and attracting posts, pages, and landing pages with Gutenberg Blocks and Template Library by Otter. Otter comes with dozens of Gutenberg blocks that are all you need to build beautiful pages.
-* [Ghost Kit – Blocks Collection](https://wordpress.org/plugins/ghostkit/) - Blocks collection and extensions for Gutenberg.
+* [Otter Blocks](https://wordpress.org/plugins/otter-blocks/) - Create beautiful and attracting posts, pages, and landing pages with Gutenberg Blocks and Template Library by Otter. Otter comes with dozens of Gutenberg blocks that are all you need to build beautiful pages.
+* [Ghost Kit](https://wordpress.org/plugins/ghostkit/) - Blocks collection and extensions for Gutenberg.
 * [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) - WooCommerce blocks for the Gutenberg editor.
-* [Easy Digital Downloads – Blocks](https://wordpress.org/plugins/edd-blocks) - Display Downloads, Categories and Tags using the new WordPress editor.
-* [Grids: Layout builder for WordPress](https://wordpress.org/plugins/grids/) - Layout builder for WordPress.
-* [Premium Blocks for Gutenberg](https://wordpress.org/plugins/premium-blocks-for-gutenberg/) - Gutenberg blocks that will help you build amazing pages with the new WordPress Gutenberg editor.
-* [Extra Gutenberg Blocks Options: Blocks Design, Style, Custom CSS](https://wordpress.org/plugins/stylist/) - Simple yet powerful visual style editor.
-* [Block Gallery – Photo Gallery Gutenberg Blocks](https://wordpress.org/plugins/block-gallery/) - The most advanced suite of gallery blocks for the Gutenberg block editor. Create stunning masonry, carousel and stacked galleries in seconds, with the brilliantly intuitive interface. Block Gallery is absolutely the best collection of native editor gallery blocks in the world.
-* [Ultimate Blocks – Custom Gutenberg Blocks](https://wordpress.org/plugins/ultimate-blocks/) - Custom Blocks for Bloggers and Marketers. Create Better Content With Gutenberg.
+* [Easy Digital Downloads Blocks](https://wordpress.org/plugins/edd-blocks) - Display Downloads, Categories and Tags using the new WordPress editor.
+* [Grids](https://wordpress.org/plugins/grids/) - Layout builder for WordPress.
+* [Premium Blocks](https://wordpress.org/plugins/premium-blocks-for-gutenberg/) - Gutenberg blocks that will help you build amazing pages with the new WordPress Gutenberg editor.
+* [Stylist](https://wordpress.org/plugins/stylist/) - Simple yet powerful visual style editor.
+* [Block Gallery](https://wordpress.org/plugins/block-gallery/) - The most advanced suite of gallery blocks for the Gutenberg block editor. Create stunning masonry, carousel and stacked galleries in seconds, with the brilliantly intuitive interface. Block Gallery is absolutely the best collection of native editor gallery blocks in the world.
+* [Ultimate Blocks](https://wordpress.org/plugins/ultimate-blocks/) - Custom Blocks for Bloggers and Marketers. Create Better Content With Gutenberg.

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ Plugins for additional [Gutenberg](https://wordpress.org/gutenberg/) block types
 * [Block Plugins](#plugins)
 
 ## Block Plugins
-* [Ultimate Addons for Gutenberg](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) - The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
-* [Stackable](https://wordpress.org/plugins/stackable-ultimate-gutenberg-blocks/) - Blocks for everyone.
 * [Advanced Gutenberg](https://wordpress.org/plugins/advanced-gutenberg/) - Enhanced tools for Gutenberg editor.
-* [Atomic Blocks](https://wordpress.org/plugins/atomic-blocks/) - A beautiful collection of handy Gutenberg blocks to help you get started with the new WordPress editor.
-* [Kadence Blocks](https://wordpress.org/plugins/kadence-blocks/) - Advanced Page Building Blocks for Gutenberg. Create custom column layouts, backgrounds, dual buttons, icons etc.
-* [CoBlocks](https://wordpress.org/plugins/coblocks/) - CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
 * [Advanced Gutenberg Blocks](https://wordpress.org/plugins/advanced-gutenberg-blocks/) - Awesome customizable blocks for the new WordPress Editor.
-* [Otter Blocks](https://wordpress.org/plugins/otter-blocks/) - Create beautiful and attracting posts, pages, and landing pages with Gutenberg Blocks and Template Library by Otter. Otter comes with dozens of Gutenberg blocks that are all you need to build beautiful pages.
-* [Ghost Kit](https://wordpress.org/plugins/ghostkit/) - Blocks collection and extensions for Gutenberg.
-* [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) - WooCommerce blocks for the Gutenberg editor.
-* [Easy Digital Downloads Blocks](https://wordpress.org/plugins/edd-blocks) - Display Downloads, Categories and Tags using the new WordPress editor.
-* [Grids](https://wordpress.org/plugins/grids/) - Layout builder for WordPress.
-* [Premium Blocks](https://wordpress.org/plugins/premium-blocks-for-gutenberg/) - Gutenberg blocks that will help you build amazing pages with the new WordPress Gutenberg editor.
-* [Stylist](https://wordpress.org/plugins/stylist/) - Simple yet powerful visual style editor.
+* [Atomic Blocks](https://wordpress.org/plugins/atomic-blocks/) - A beautiful collection of handy Gutenberg blocks to help you get started with the new WordPress editor.
 * [Block Gallery](https://wordpress.org/plugins/block-gallery/) - The most advanced suite of gallery blocks for the Gutenberg block editor. Create stunning masonry, carousel and stacked galleries in seconds, with the brilliantly intuitive interface. Block Gallery is absolutely the best collection of native editor gallery blocks in the world.
+* [CoBlocks](https://wordpress.org/plugins/coblocks/) - CoBlocks is a suite of professional page building content blocks for the WordPress Gutenberg block editor. Our blocks are hyper-focused on empowering makers to build beautifully rich pages in WordPress.
+* [Easy Digital Downloads Blocks](https://wordpress.org/plugins/edd-blocks) - Display Downloads, Categories and Tags using the new WordPress editor.
+* [Ghost Kit](https://wordpress.org/plugins/ghostkit/) - Blocks collection and extensions for Gutenberg.
+* [Grids](https://wordpress.org/plugins/grids/) - Layout builder for WordPress.
+* [Kadence Blocks](https://wordpress.org/plugins/kadence-blocks/) - Advanced Page Building Blocks for Gutenberg. Create custom column layouts, backgrounds, dual buttons, icons etc.
+* [Otter Blocks](https://wordpress.org/plugins/otter-blocks/) - Create beautiful and attracting posts, pages, and landing pages with Gutenberg Blocks and Template Library by Otter. Otter comes with dozens of Gutenberg blocks that are all you need to build beautiful pages.
+* [Premium Blocks](https://wordpress.org/plugins/premium-blocks-for-gutenberg/) - Gutenberg blocks that will help you build amazing pages with the new WordPress Gutenberg editor.
+* [Stackable](https://wordpress.org/plugins/stackable-ultimate-gutenberg-blocks/) - Blocks for everyone.
+* [Stylist](https://wordpress.org/plugins/stylist/) - Simple yet powerful visual style editor.
+* [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) - WooCommerce blocks for the Gutenberg editor.
+* [Ultimate Addons for Gutenberg](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) - The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
 * [Ultimate Blocks](https://wordpress.org/plugins/ultimate-blocks/) - Custom Blocks for Bloggers and Marketers. Create Better Content With Gutenberg.


### PR DESCRIPTION
This PR removes the extra information that folks add to the WordPress.org plugin title, to promote clarity and make the list much more readable. 

I've also organized the list in alphabetical order. 